### PR TITLE
Add tab support

### DIFF
--- a/src/html-duration-picker.js
+++ b/src/html-duration-picker.js
@@ -388,6 +388,16 @@ export default (function() {
             }
           }
         });
+
+        if (btn === scrollUpBtn) {
+          btn.addEventListener('keydown', (event) => {
+            if (event.key === 'Tab' && event.shiftKey) {
+              highlightIncrementArea(picker, 1);
+              event.preventDefault();
+            }
+          });
+        }
+
         btn.addEventListener('keyup', (event) => {
           if (event.key == 'Enter') {
             const adjustmentFactor = getAdjustmentFactor(picker);

--- a/src/html-duration-picker.js
+++ b/src/html-duration-picker.js
@@ -262,13 +262,14 @@ export default (function() {
     // Allow tab to change selection and escape the input
     if (event.key === 'Tab') {
       const preAdjustmentFactor = getAdjustmentFactor(event.target);
+      const rightAdjustValue = shouldHideSeconds(event.target) ? 3600 : 60;
       const direction = event.shiftKey ? 'left' : 'right';
 
       shiftFocus(event.target, direction);
 
       if (
         (direction === 'left' && preAdjustmentFactor < 3600) ||
-        (direction === 'right' && preAdjustmentFactor >= 60)
+        (direction === 'right' && preAdjustmentFactor >= rightAdjustValue)
       ) {
         event.preventDefault();
       }

--- a/src/html-duration-picker.js
+++ b/src/html-duration-picker.js
@@ -259,6 +259,21 @@ export default (function() {
       event.preventDefault();
     }
 
+    // Allow tab to change selection and escape the input
+    if (event.key === 'Tab') {
+      const preAdjustmentFactor = getAdjustmentFactor(event.target);
+      const direction = event.shiftKey ? 'left' : 'right';
+
+      shiftFocus(event.target, direction);
+
+      if (
+        (direction === 'left' && preAdjustmentFactor < 3600) ||
+        (direction === 'right' && preAdjustmentFactor >= 60)
+      ) {
+        event.preventDefault();
+      }
+    }
+
     // The following keys will be accepted when the input field is selected
     const acceptedKeys = ['Backspace', 'ArrowDown', 'ArrowUp', 'Tab'];
     if (isNaN(event.key) && !acceptedKeys.includes(event.key)) {


### PR DESCRIPTION
I thought to do this due to issue #101 

I added support for switching between the hours/minutes/seconds field using tab and shift+tab. If the next/prev selection would be in the input, change the highlighted area, otherwise act like a normal tab and leave the input.

I'm happy to make any changes and I will not be offended if you don't want to implement this.