### PR TITLE
Add hour digit limit option

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -29,6 +29,17 @@
     <br>
     <input type="text" class="html-duration-picker" data-duration="00:29:50" data-duration-min="00:30:10" data-duration-max="00:31:05">
     <br>  <br>
+
+    Duration Input box with use of maximum hour digit setting. (max of 2 digits in example)
+    <br />
+    <code>
+      &#x3C;input type=&#x22;text&#x22; class=&#x22;html-duration-picker&#x22; data-hour-digit-limit=&#x22;2&#x22;&#x3E;
+    </code>
+    <br />
+    <input type="text" class="html-duration-picker" data-hour-digit-limit="2" />
+
+    <br /><br />
+
     <div class="row">
         <div class="col-12">
                 Bootstrap Input box <br><code>&#x3C;input type=&#x22;text&#x22; class=&#x22;form-control&#x22;&#x3E;</code><br>


### PR DESCRIPTION
Implements #101 

- Added a validation check for the hour limit to keep it under the digit limit
-  If a limit is set and the digit limit is hit, move the cursor to the minutes section

I did not handle a conflict between `data-duration-min` and `data-hour-digit-limit`. Right now it'll end up setting the hours to 0 no matter what if the `data-duration-min` would result in more digits than allowed in `data-hour-digit-limit`. Not sure if there should be any check for that or if it's obvious enough why that would be a problem that one isn't needed.