### PR TITLE
fixed bug making seconds appear on hidden seconds input

### DIFF
--- a/src/html-duration-picker.js
+++ b/src/html-duration-picker.js
@@ -427,8 +427,8 @@ export default (function () {
       event.target,
       durationToSeconds(event.target.value),
     );
-    if (event.target.value != secondsToDuration(constrainedValue)) {
-      event.target.value = secondsToDuration(constrainedValue);
+    if (event.target.value != secondsToDuration(constrainedValue, hideSeconds)) {
+      event.target.value = secondsToDuration(constrainedValue, hideSeconds);
     }
   };
 


### PR DESCRIPTION
blur event handler was missing a hideSeconds parameter in the function call. Appears to be fixed on the local development server.